### PR TITLE
ci/lint: Add `envoy.code.check`

### DIFF
--- a/.code-check.yaml
+++ b/.code-check.yaml
@@ -1,0 +1,27 @@
+# Configuration for envoy.code.check
+ignores:
+  # Add any files or directories you want to exclude from linting
+  - ".git"
+  - "__pycache__"
+  - "*.pyc"
+  - "venv"
+  - ".venv"
+
+# Lint configuration
+lint:
+  enable:
+    - flake8
+    - isort
+    - black
+  
+  # Define specific settings for each tool
+  settings:
+    flake8:
+      max-line-length: 100
+      exclude: ['venv', '.venv', '__pycache__']
+    isort:
+      line_length: 100
+      multi_line_output: 3
+      include_trailing_comma: true
+    black:
+      line-length: 100

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,22 @@
+[flake8]
+max-line-length = 100
+exclude = 
+    .git,
+    __pycache__,
+    build,
+    dist,
+    venv,
+    .venv
+
+# Ignore specific errors
+ignore =
+    # W503: line break before binary operator
+    W503,
+    # E203: whitespace before ':'
+    E203,
+    # E501: line too long (handled by black)
+    E501
+
+per-file-ignores =
+    # F401: imported but unused
+    __init__.py: F401

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -29,4 +29,4 @@ jobs:
 
     - name: Lint with envoy.code.check
       run: |
-        python -m envoy.code.check remember_me_mcp_server/
+        envoy.code.check . -c yamllint -c python_flake8

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,32 @@
+name: Python Linting
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install envoy.code.check
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Lint with envoy.code.check
+      run: |
+        python -m envoy.code.check remember_me_mcp_server/

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,28 @@
+extends: default
+
+rules:
+  document-start: false
+  indentation:
+    spaces: consistent
+    indent-sequences: false
+  line-length:
+    # This can be adjusted if there is a very good reason.
+    max: 140
+    level: error
+    allow-non-breakable-words: true
+  truthy:
+    allowed-values:
+    - "yes"
+    - "no"
+    - "true"
+    - "false"
+    # https://github.com/adrienverge/yamllint/issues/430
+    - "on"
+
+yaml-files:
+- .clang-format
+- "*.yml"
+- "*.yaml"
+
+ignore:
+- "**/node_modules/*"

--- a/remember_me_mcp_server/backup.py
+++ b/remember_me_mcp_server/backup.py
@@ -28,7 +28,7 @@ class Backup:
         for path in paths:
             path.unlink()
 
-    def create(self, name: str | None = None) -> None:
+    def create(self, name: str | None = None) -> str:
         name = name or time.time_ns()
         backup_path = self.path / f"{name}.{self.target_path.name}"
         if backup_path.exists():
@@ -48,5 +48,5 @@ class Backup:
     def restore(self, name: str) -> None:
         backup_path = self.path / f"{name}.{self.target_path.name}"
         if not backup_path.exists():
-            raise BackupError(f"Backup doesnt exist: {name}")
+            raise BackupError(f"Backup does not exist: {name}")
         shutil.copy(backup_path, self.target_path)

--- a/remember_me_mcp_server/context.py
+++ b/remember_me_mcp_server/context.py
@@ -40,12 +40,14 @@ class PersistentResource:
             include_content=False
     ) -> list[dict]:
         cursor = self.db.cursor()
-        cursor.execute(*
-            (f"SELECT key, type, {self.resource_name} FROM {self.resource_table} WHERE context = ?",
-             (context,))
-            if include_content
-            else (f"SELECT key, type FROM {self.resource_table} WHERE context = ?",
-                  (context,)))
+        if include_content:
+            cursor.execute(
+                f"SELECT key, type, {self.resource_name} FROM {self.resource_table} WHERE context = ?",
+                (context,))
+        else:
+            cursor.execute(
+                f"SELECT key, type FROM {self.resource_table} WHERE context = ?",
+                (context,))
         return [
             {"key": row[0], "mime_type": row[1], self.resource_name: row[2]}
             if include_content

--- a/remember_me_mcp_server/errors.py
+++ b/remember_me_mcp_server/errors.py
@@ -1,5 +1,3 @@
-
-
 class BackupError(Exception):
     pass
 

--- a/remember_me_mcp_server/server.py
+++ b/remember_me_mcp_server/server.py
@@ -1,21 +1,10 @@
-import argparse
-import asyncio
-import base64
-import collections
-import hashlib
 import json
-import os
 import pathlib
-import re
-import signal
-import sys
-import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
-from mcp.server.fastmcp import Context, Image, FastMCP
-from mcp.server.fastmcp.prompts import base
+from mcp.server.fastmcp import Context, FastMCP
 
 from remember_me_mcp_server.backup import Backup
 from remember_me_mcp_server.context import MyContext
@@ -31,6 +20,7 @@ ResultDict = dict[str, str | bool | dict]
 class AppContext:
     backup: Backup
     my: MyContext
+
 
 # TODO: re/move this once resource contexts are fixed
 my = MyContext(MY_CONTEXT_DB_PATH)
@@ -78,14 +68,14 @@ async def my_context(ctx: Context, extra_context: list[str] | None = None) -> Re
 
     This MUST always be loaded when working with me.
     """
-    rules = await ctx.read_resource(f"my://me/rule")
+    rules = await ctx.read_resource("my://me/rule")
     for extra in (extra_context or []):
         rules += await ctx.read_resource(f"my://{extra}/rule")
     result = []
     for c in rules:
         for rule in json.loads(c.content):
             result.append(f"{rule['policy']}: {rule['rule']}")
-    summary = await ctx.read_resource(f"my://me/summary:all")
+    summary = await ctx.read_resource("my://me/summary:all")
     summary_result = []
     for c in summary:
         for _summary in json.loads(c.content):
@@ -97,7 +87,7 @@ async def my_context(ctx: Context, extra_context: list[str] | None = None) -> Re
             for _summary in json.loads(c.content):
                 _summary["context"] = extra
                 summary_result.append(_summary)
-    snippet = await ctx.read_resource(f"my://me/snippet")
+    snippet = await ctx.read_resource("my://me/snippet")
     snippet_result = []
     for c in snippet:
         for _snippet in json.loads(c.content):
@@ -117,7 +107,7 @@ async def my_context(ctx: Context, extra_context: list[str] | None = None) -> Re
             summary=summary_result))
 
 
-## SNIPPETS
+# SNIPPETS
 
 @mcp.tool()
 async def my_context_snippet_get(
@@ -211,7 +201,7 @@ async def my_context_snippet_set(
         return dict(success=False, error=str(e))
 
 
-## Summary
+# Summary
 
 @mcp.tool()
 async def my_context_summary_get(
@@ -306,7 +296,7 @@ async def my_context_summary_set(
         return dict(success=False, error=str(e))
 
 
-## Rules
+# Rules
 
 @mcp.tool()
 async def my_context_rule_list(
@@ -354,7 +344,7 @@ async def my_context_rule_set(
         return dict(success=False, error=str(e))
 
 
-## Backups
+# Backups
 
 
 @mcp.tool()


### PR DESCRIPTION
This commit adds:
1. GitHub Actions workflow for Python linting using envoy.code.check with Python 3.12
2. A configuration file (.code-check.yaml) for the linter
   
The workflow will run on push to main branch and on pull requests targeting the main branch. It checks the Python code quality using flake8, isort, and black via the envoy.code.check tool.

Python 3.12 is used to align with current development practices.